### PR TITLE
Update MountSpy.lua

### DIFF
--- a/MountSpy.lua
+++ b/MountSpy.lua
@@ -569,7 +569,7 @@ function MountSpy_ReceiveCommand(msg)
 			MountSpySuppressLoadingMessages = false;
 			print(MountSpyPrintPrefix, "Startup messages enabled.");
 		end	
-	elseif string.find(msg, "?") > 0 then
+	elseif string.find(msg, "?") and string.find(msg, "?") > 0 then
 		MountSpy_StringSearch(msg);
 	else
 		MountSpyPrint("Unknown command.");


### PR DESCRIPTION
Added a null-check when the argument has a null 
i.e.: /mountspy info
this shouldn't trigger anything, but it runs afoul of the string.find(msg.,"?") > 0